### PR TITLE
feat: implementing Shape interface, Rectangle, Circle struct and test…

### DIFF
--- a/lqm/week1/interface/interface.go
+++ b/lqm/week1/interface/interface.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"math"
+)
+
+type Shape interface {
+	Area() float64
+	Perimeter() float64
+}
+
+type Circle struct {
+	r float64
+}
+
+type Rectangle struct {
+	h, w float64
+}
+
+func (c Circle) Area() float64 {
+	return c.r * c.r * math.Pi
+}
+
+func (c Circle) Perimeter() float64 {
+	return 2 * c.r * math.Pi
+}
+
+func (r Rectangle) Area() float64 {
+	return r.h * r.w
+}
+
+func (r Rectangle) Perimeter() float64 {
+	return 2 * (r.h + r.w)
+}

--- a/lqm/week1/interface/interface_test.go
+++ b/lqm/week1/interface/interface_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"testing"
+	"math"
+)
+
+func TestShapeCalculations(t *testing.T) {
+	areaTests := []struct {
+		name string
+		shape Shape
+		area float64
+		perimeter float64
+	}{
+		{
+			name: "Rectangle",
+			shape: Rectangle{1.0, 2.0}, 
+			area: 2.0, 
+			perimeter: 6.0,
+		},
+		{
+			name: "Circle",
+			shape: Circle{1.5}, 
+			area: math.Pi * 1.5 * 1.5,
+			perimeter: 2 * math.Pi * 1.5,
+		},
+	}
+
+	for _, tt := range areaTests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotArea := tt.shape.Area()
+			wantArea := tt.area
+			assertCorrectResult(t, gotArea, wantArea)
+
+			gotPerimeter := tt.shape.Perimeter()
+			wantPerimeter := tt.perimeter
+			assertCorrectResult(t, gotPerimeter, wantPerimeter)
+		})
+	}
+}
+
+func assertCorrectResult(t testing.TB, got, want float64) {
+	t.Helper()
+	if got != want {
+		t.Errorf("expected %g but got %g instead", want, got)
+	}
+}


### PR DESCRIPTION
# What
This pull request is to implement interface Shape with area and perimeter calculation methods, struct Rectangle and Circle that implements interface Shape, and testing calculation methods using GoLang

# Evidence

<img width="568" alt="Screenshot 2025-02-27 at 16 29 06" src="https://github.com/user-attachments/assets/f63025c7-2b8b-401b-a6a8-176fd9ffa9c9" />
